### PR TITLE
[PLUGIN-1151] Correct Functionality of "Last Data Column Index" config in Google Sheets Source

### DIFF
--- a/docs/GoogleSheets-batchsource.md
+++ b/docs/GoogleSheets-batchsource.md
@@ -120,7 +120,8 @@ _Treat first row as column names_ - the plugin uses first row for schema definin
 **Custom Row Index For Column Names:** Number of the row to be treated as a header.
 Only shown when the 'Column Names Selection' field is set to 'Custom row as column names' header.
 
-**Last Data Column Index:** Last column plugin will read as data.
+**Last Data Column Index:** Last column plugin will read as data. It will be ignored if the Column 
+Names Row contains less number of columns.
 
 **Last Data Row Index:** Last row plugin will read as data.
 


### PR DESCRIPTION
[PLUGIN-1151](https://cdap.atlassian.net/browse/PLUGIN-1151)

This PR corrects the behaviour of "Last Data Column Index" config which will now be considered if the column names row used to detect schema contains less no of columns than the actual row size otherwise ignored as discussed with product team.