### PR TITLE
[PLUGIN-1466] Bump Hadoop dependency version to fix log4j vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.1.1</cdap.version>
-    <cdap.plugin.version>2.3.5</cdap.plugin.version>
+    <cdap.version>6.8.0</cdap.version>
+    <cdap.plugin.version>2.10.0</cdap.plugin.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-lang3.version>3.9</commons-lang3.version>
     <drive-api.version>v3-rev162-1.23.0</drive-api.version>
     <easymock.version>4.0.2</easymock.version>
     <guava.retrying.version>2.0.0</guava.retrying.version>
-    <hadoop.version>2.8.0</hadoop.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <junit.version>4.11</junit.version>
     <powermock.version>1.6.5</powermock.version>
     <sheets-api.version>v4-rev581-1.25.0</sheets-api.version>
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline</artifactId>
+      <artifactId>cdap-data-pipeline2_2.11</artifactId>
       <version>${cdap.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -268,8 +268,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.1.1,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.1.1,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.8.0,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>


### PR DESCRIPTION
[PLUGIN-1466] Bump Hadoop dependency version in data-integrations/google-drive to fix log4j vulnerabilities