### PR TITLE
Set column dimension to match record dimension

### DIFF
--- a/src/main/java/io/cdap/plugin/google/sheets/sink/GoogleSheetsRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/google/sheets/sink/GoogleSheetsRecordWriter.java
@@ -155,8 +155,7 @@ public class GoogleSheetsRecordWriter extends RecordWriter<NullWritable, Flatter
 
       // 3. extend column dimension if needed
       if (record.getHeader().getWidth() > sheetsColumnCount.get(spreadsheetName).get(sheetTitle)) {
-        int extensionSize = record.getHeader().getWidth() -
-          sheetsRowCount.get(spreadsheetName).get(sheetTitle);
+        int extensionSize = record.getHeader().getWidth();
         sheetsSinkClient.extendDimension(spreadsheetId, spreadsheetName, sheetTitle, sheetId, extensionSize,
           DimensionType.COLUMNS);
         sheetsColumnCount.get(spreadsheetName).put(sheetTitle, record.getHeader().getWidth());


### PR DESCRIPTION
Column dimension is being incorrectly extended by the difference between record dimension and column dimension.  We should set column extension to match record dimension.