### PR TITLE
[PLUGIN-1746] Use GoogleCredentials library when service account authentication type is used

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+# Copyright © 2024 Cask Data, Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+# Note: Any changes to this workflow would be used only after merging into develop
+name: Build with unit tests
+
+on:
+  workflow_run:
+    workflows:
+    - Trigger build
+    types:
+    - completed
+
+jobs:
+  build:
+    runs-on: k8s-runner-build
+
+    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
+
+    steps:
+    # Pinned 1.0.0 version
+    - uses: marocchino/action-workflow_run-status@54b6e87d6cb552fc5f36dbe9a722a6048725917a
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
+    - name: Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-${{ github.workflow }}
+    - name: Build with Maven
+      run: mvn clean test -fae -T 2 -B -V -DcloudBuild -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+    - name: Archive build artifacts
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: Build debug files
+        path: |
+          **/target/rat.txt
+          **/target/surefire-reports/*
+    - name: Surefire Report
+      # Pinned 1.0.5 version
+      uses: ScaCap/action-surefire-report@ad808943e6bfbd2e6acba7c53fdb5c89534da533
+      if: always()
+      with:
+        # GITHUB_TOKEN
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        commit: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -1,0 +1,47 @@
+# Copyright © 2021 Cask Data, Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# This workflow will trigger build.yml only when needed.
+# This way we don't flood main workflow run list
+# Note that build.yml from develop will be used even for PR builds
+# Also it will have access to the proper GITHUB_SECRET
+
+name: Trigger build
+
+on:
+  push:
+    branches: [ develop, release/** ]
+  pull_request:
+    branches: [ develop, release/** ]
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+
+    # We allow builds:
+    # 1) When triggered manually
+    # 2) When it's a merge into a branch
+    # 3) For PRs that are labeled as build and
+    #  - It's a code change
+    #  - A build label was just added
+    # A bit complex, but prevents builds when other labels are manipulated
+    if: >
+      github.event_name == 'workflow_dispatch'
+      || github.event_name == 'push'
+      || (contains(github.event.pull_request.labels.*.name, 'build')
+         && (github.event.action != 'labeled' || github.event.label.name == 'build')
+         )
+
+    steps:
+    - name: Trigger build
+      run: echo Maven build will be triggered now

--- a/docs/GoogleDrive-batchsink.md
+++ b/docs/GoogleDrive-batchsink.md
@@ -59,13 +59,13 @@ specified service account email. To write files to a Shared Google Drive Folder,
 specified service account.
 
 * **Service Account File Path**: Path on the local file system of the service account key used for
-  authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
-  When running on other clusters, the file must be present on every node in the cluster.
-  
-  When set to 'auto-detect', the GCE VM needs to be configured with the scope required by the Google Drive API.
-  Otherwise, the preview as well as pipeline run will fail with insufficient permission error. The required scope
-  is `https://www.googleapis.com/auth/drive`.
+  authorization.
 
+  Can be set to 'auto-detect' when running on a Dataproc cluster which needs to be 
+  created with the following scopes: 
+  * https://www.googleapis.com/auth/drive
+
+  When running on other clusters, the file must be present on every node in the cluster.
 
 * **Service Account JSON**: Contents of the service account JSON file. Service Account JSON can be generated on Google Cloud
   [Service Account page](https://console.cloud.google.com/iam-admin/serviceaccounts) 

--- a/docs/GoogleDrive-batchsource.md
+++ b/docs/GoogleDrive-batchsource.md
@@ -72,13 +72,13 @@ Make sure that the Google Drive Folder is shared with the specified service acco
 `Viewer` role must be granted to the specified service account to read files from the Google Drive Folder.
 
 * **Service Account File Path**: Path on the local file system of the service account key used for
-  authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
-  When running on other clusters, the file must be present on every node in the cluster.
+  authorization.
 
-  When set to 'auto-detect', the GCE VM needs to be configured with the scope required by the Google Drive API.
-  Otherwise, the preview as well as pipeline run will fail with insufficient permission error. The required scope
-  is `https://www.googleapis.com/auth/drive.readonly`.
-  
+  Can be set to 'auto-detect' when running on a Dataproc cluster which needs to be
+  created with the following scopes:
+  * https://www.googleapis.com/auth/drive.readonly
+
+  When running on other clusters, the file must be present on every node in the cluster.
 
 * **Service Account JSON**: Contents of the service account JSON file. Service Account JSON can be generated on Google Cloud
   [Service Account page](https://console.cloud.google.com/iam-admin/serviceaccounts)

--- a/docs/GoogleSheets-batchsink.md
+++ b/docs/GoogleSheets-batchsink.md
@@ -61,13 +61,14 @@ To write files to a Private Google Drive, grant the `Editor` role to the specifi
 To write files to a Shared Google Drive Folder, grant the `Contributor` role to the specified service account.
 
 * **Service Account File Path**: Path on the local file system of the service account key used for
-  authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
+  authorization.
+
+  Can be set to 'auto-detect' when running on a Dataproc cluster which needs to be
+  created with the following scopes:
+  * https://www.googleapis.com/auth/drive
+  * https://www.googleapis.com/auth/spreadsheets
+
   When running on other clusters, the file must be present on every node in the cluster.
-
-  When set to 'auto-detect', the GCE VM needs to be configured with the scope required by the Google Drive API.
-  Otherwise, the preview as well as pipeline run will fail with insufficient permission error. The required scopes
-  are `https://www.googleapis.com/auth/drive` and `https://www.googleapis.com/auth/spreadsheets`.
-
 
 * **Service Account JSON**: Contents of the service account JSON file. Service Account JSON can be generated on Google Cloud
   [Service Account page](https://console.cloud.google.com/iam-admin/serviceaccounts)

--- a/docs/GoogleSheets-batchsource.md
+++ b/docs/GoogleSheets-batchsource.md
@@ -69,13 +69,14 @@ Make sure that the Google Drive Folder is shared with the specified service acco
 `Viewer` role must be granted to the specified service account to read files from the Google Drive Folder.
 
 * **Service Account File Path**: Path on the local file system of the service account key used for
-  authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
+  authorization. 
+
+  Can be set to 'auto-detect' when running on a Dataproc cluster which needs to be
+  created with the following scopes:
+  * https://www.googleapis.com/auth/drive
+  * https://www.googleapis.com/auth/spreadsheets.readonly
+  
   When running on other clusters, the file must be present on every node in the cluster.
-
-  When set to 'auto-detect', the GCE VM needs to be configured with the scope required by the Google Drive API.
-  Otherwise, the preview as well as pipeline run will fail with insufficient permission error. The required scopes
-  are `https://www.googleapis.com/auth/drive` and `https://www.googleapis.com/auth/spreadsheets.readonly`.
-
 
 * **Service Account JSON**: Contents of the service account JSON file. Service Account JSON can be generated on Google Cloud
   [Service Account page](https://console.cloud.google.com/iam-admin/serviceaccounts)

--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,15 @@
     <cdap.plugin.version>2.10.0</cdap.plugin.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-lang3.version>3.9</commons-lang3.version>
-    <drive-api.version>v3-rev162-1.23.0</drive-api.version>
+    <drive-api.version>v3-rev197-1.25.0</drive-api.version>
     <easymock.version>4.0.2</easymock.version>
+    <google.auth.oauth2.http.version>1.23.0</google.auth.oauth2.http.version>
     <guava.retrying.version>2.0.0</guava.retrying.version>
+    <guava.version>33.0.0-jre</guava.version>
     <hadoop.version>2.10.2</hadoop.version>
     <junit.version>4.11</junit.version>
     <powermock.version>1.6.5</powermock.version>
-    <sheets-api.version>v4-rev581-1.25.0</sheets-api.version>
+    <sheets-api.version>v4-rev612-1.25.0</sheets-api.version>
   </properties>
 
   <repositories>
@@ -92,6 +94,24 @@
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-sheets</artifactId>
       <version>${sheets-api.version}</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.google.auth/google-auth-library-oauth2-http -->
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>${google.auth.oauth2.http.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/cdap/plugin/google/common/GoogleAuthBaseConfig.java
+++ b/src/main/java/io/cdap/plugin/google/common/GoogleAuthBaseConfig.java
@@ -189,12 +189,6 @@ public abstract class GoogleAuthBaseConfig extends PluginConfig {
     final Boolean serviceAccountFilePath = isServiceAccountFilePath();
     final Boolean serviceAccountJson = isServiceAccountJson();
 
-    // we don't want the validation to fail because the VM used during the validation
-    // may be different from the VM used during runtime and may not have the Google Drive Api scope.
-    if (serviceAccountFilePath && AUTO_DETECT_VALUE.equalsIgnoreCase(accountFilePath)) {
-      return false;
-    }
-
     if (serviceAccountFilePath != null && serviceAccountFilePath) {
       if (!AUTO_DETECT_VALUE.equals(accountFilePath) && !new File(accountFilePath).exists()) {
         collector.addFailure("Service Account File Path is not available.",


### PR DESCRIPTION
[PLUGIN-1746](https://cdap.atlassian.net/browse/PLUGIN-1746)

context: Deprecated [Google Credential API](https://github.com/googleapis/google-api-java-client/blob/b1d425cb8cf336bbae06c33a56b522b8fded2dc0/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java#L466-L471) does not set the access scopes when `serviceAccountKey` is `null`.