### PR TITLE
[🍒][PLUGIN-1762][PLUGIN-1763][PLUGIN-1764][PLUGIN-1766]

### DIFF
--- a/docs/GoogleDrive-batchsink.md
+++ b/docs/GoogleDrive-batchsink.md
@@ -40,6 +40,11 @@ Make sure `Google Drive API` is enabled in the `GCP Project`.
 OAuth2 client credentials can be generated on Google Cloud
 [Credentials Page](https://console.cloud.google.com/apis/credentials)
 
+**OAuth Method:** The method used to get OAuth access tokens. Users have the option to either directly provide
+the OAuth access token or supply a client ID, client secret, and refresh token.
+
+**Access Token:** Short lived access token used for connecting.
+
 **Client ID:** OAuth2 client id used to identify the application.
 
 **Client Secret:** OAuth2 client secret used to access the authorization server.

--- a/docs/GoogleDrive-batchsource.md
+++ b/docs/GoogleDrive-batchsource.md
@@ -9,13 +9,25 @@ Properties
 ----------
 ### Basic
 
-**Directory Identifier:** Identifier of the destination folder.
+**Identifier Type:** Identifier specifies whether the given ID for Google Drive entity is a file or directory.
+
+**Directory Identifier:** Identifier of the source folder.
 
 This comes after `folders/` in the URL. For example, if the URL is
 ```
 https://drive.google.com/drive/folders/1dyUEebJaFnWa3Z4n0BFMVAXQ7mfUH11g?resourcekey=0-XVijrJSp3E3gkdJp20MpCQ
 ```
 Then the Directory Identifier would be `1dyUEebJaFnWa3Z4n0BFMVAXQ7mfUH11g`.
+
+**File Identifier:** Identifier of the file.
+
+This comes after `file/d/ or document/d/ or spreadsheets/d/` in the URL. For example, if the URL is
+```
+https://docs.google.com/file/d/17W3vOhBwe0i24OdVNsbz8rAMClzUitKeAbumTqWFrkows
+```
+
+Then the File Identifier would be `17W3vOhBwe0i24OdVNsbz8rAMClzUitKeAbumTqWFrkows`.  
+**Note:** Either Directory Identifier or File Identifier should have a value.
 
 **File Metadata Properties:** Properties that represent metadata of files. 
 They will be a part of output structured record. Descriptions for properties can be view at 
@@ -48,7 +60,10 @@ For Google Drive formats user should specify exporting format in **Exporting** s
 **Authentication Type:** Type of authentication used to access Google API. 
 
 OAuth2 and Service Account types are available.
-Make sure `Google Drive API` is enabled in the `GCP Project`.
+
+Make sure that:
+* `Google Drive API` is enabled in the `GCP Project`.
+* `Google Drive Folder` is shared to the service account email used with the required permission.
 
 #### OAuth2 Properties
 

--- a/docs/GoogleDrive-batchsource.md
+++ b/docs/GoogleDrive-batchsource.md
@@ -55,6 +55,11 @@ Make sure `Google Drive API` is enabled in the `GCP Project`.
 OAuth2 client credentials can be generated on Google Cloud
 [Credentials Page](https://console.cloud.google.com/apis/credentials)
 
+**OAuth Method:** The method used to get OAuth access tokens. Users have the option to either directly provide
+the OAuth access token or supply a client ID, client secret, and refresh token.
+
+**Access Token:** Short lived access token used for connecting.
+
 **Client ID:** OAuth2 client id used to identify the application.
 
 **Client Secret:** OAuth2 client secret used to access the authorization server.

--- a/docs/GoogleSheets-batchsink.md
+++ b/docs/GoogleSheets-batchsink.md
@@ -43,6 +43,11 @@ Make sure `Google Drive API` and `Google Sheets API` is enabled in the `GCP Proj
 OAuth2 client credentials can be generated on Google Cloud
 [Credentials Page](https://console.cloud.google.com/apis/credentials)
 
+**OAuth Method:** The method used to get OAuth access tokens. Users have the option to either directly provide
+the OAuth access token or supply a client ID, client secret, and refresh token.
+
+**Access Token:** Short lived access token used for connecting.
+
 **Client ID:** OAuth2 client id used to identify the application.
 
 **Client Secret:** OAuth2 client secret used to access the authorization server.

--- a/docs/GoogleSheets-batchsource.md
+++ b/docs/GoogleSheets-batchsource.md
@@ -140,6 +140,9 @@ _Treat first row as column names_ - the plugin uses first row for schema definin
 **Column Names Row Number:** Number of the row to be treated as a header.
 Only shown when the 'Column Names Selection' field is set to 'Custom row as column names' header.
 
+**Auto Detect Number of Rows and Columns:** Field to enable automatic detection of the number of rows and columns to
+read from the sheet.
+
 **Number of Columns to Read:** Last column plugin will read as data. It will be ignored if the Column 
 Names Row contains less number of columns.
 

--- a/docs/GoogleSheets-batchsource.md
+++ b/docs/GoogleSheets-batchsource.md
@@ -52,6 +52,11 @@ Make sure `Google Drive API` and `Google Sheets API` is enabled in the `GCP Proj
 OAuth2 client credentials can be generated on Google Cloud 
 [Credentials Page](https://console.cloud.google.com/apis/credentials)
 
+**OAuth Method:** The method used to get OAuth access tokens. Users have the option to either directly provide
+the OAuth access token or supply a client ID, client secret, and refresh token.
+
+**Access Token:** Short lived access token used for connecting.
+
 **Client ID:** OAuth2 client id used to identify the application.
 
 **Client Secret:** OAuth2 client secret used to access the authorization server.

--- a/docs/GoogleSheets-batchsource.md
+++ b/docs/GoogleSheets-batchsource.md
@@ -9,13 +9,24 @@ Properties
 ----------
 ### Basic
 
-**Directory Identifier:** Identifier of the destination folder.
+**Identifier Type:**  Identifier specifies whether the given ID for Google Drive entity is a file or directory.
+
+**Directory Identifier:** Identifier of the source folder.
 
 This comes after `folders/` in the URL. For example, if the URL is
 ```
 https://drive.google.com/drive/folders/1dyUEebJaFnWa3Z4n0BFMVAXQ7mfUH11g?resourcekey=0-XVijrJSp3E3gkdJp20MpCQ
 ```
 Then the Directory Identifier would be `1dyUEebJaFnWa3Z4n0BFMVAXQ7mfUH11g`.
+
+**File Identifier:** Identifier of the spreadsheet file.
+
+This comes after `spreadsheets/d/` in the URL. For example, if the URL is
+```
+https://docs.google.com/spreadsheets/d/17W3vOhBwe0i24OdVNsbz8rAMClzUitKeAbumTqWFrkows
+```
+Then the File Identifier would be `17W3vOhBwe0i24OdVNsbz8rAMClzUitKeAbumTqWFrkows`.  
+**Note:** Either Directory Identifier or File Identifier should have a value.
 
 ### Filtering
 
@@ -45,7 +56,10 @@ Is shown only when 'titles' or 'numbers' are selected for 'Sheets to pull' field
 **Authentication Type:** Type of authentication used to access Google API.
 
 OAuth2 and Service Account types are available.
-Make sure `Google Drive API` and `Google Sheets API` is enabled in the `GCP Project`.
+
+Make sure that:
+* `Google Drive API` and `Google Sheets API` is enabled in the `GCP Project`.
+* `Google Drive Folder` is shared to the service account email used with the required permission.
 
 #### OAuth2 Properties
 

--- a/src/main/java/io/cdap/plugin/google/common/GoogleDriveClient.java
+++ b/src/main/java/io/cdap/plugin/google/common/GoogleDriveClient.java
@@ -88,13 +88,18 @@ public class GoogleDriveClient<C extends GoogleAuthBaseConfig> {
   }
 
   protected Credential getOAuth2Credential() {
-    GoogleCredential credential = new GoogleCredential.Builder()
-        .setTransport(httpTransport)
-        .setJsonFactory(JSON_FACTORY)
-        .setClientSecrets(config.getClientId(),
-            config.getClientSecret())
-        .build();
-    credential.createScoped(getRequiredScopes()).setRefreshToken(config.getRefreshToken());
+    GoogleCredential credential;
+    GoogleCredential.Builder builder = new GoogleCredential.Builder()
+      .setTransport(httpTransport)
+      .setJsonFactory(JSON_FACTORY);
+    if (OAuthMethod.ACCESS_TOKEN.equals(config.getOAuthMethod())) {
+      credential = builder.build();
+      credential.createScoped(getRequiredScopes()).setAccessToken(config.getAccessToken());
+    } else {
+      credential = builder.setClientSecrets(config.getClientId(),
+                                            config.getClientSecret()).build();
+      credential.createScoped(getRequiredScopes()).setRefreshToken(config.getRefreshToken());
+    }
     return credential;
   }
 

--- a/src/main/java/io/cdap/plugin/google/common/GoogleDriveClient.java
+++ b/src/main/java/io/cdap/plugin/google/common/GoogleDriveClient.java
@@ -43,7 +43,6 @@ import java.util.List;
  */
 public class GoogleDriveClient<C extends GoogleAuthBaseConfig> {
   private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
-  private static final String ROOT_FOLDER_ID = "root";
   protected final Drive service;
   protected final C config;
   protected NetHttpTransport httpTransport;
@@ -126,11 +125,11 @@ public class GoogleDriveClient<C extends GoogleAuthBaseConfig> {
     return Collections.singletonList(DriveScopes.DRIVE_READONLY);
   }
 
-  public void checkRootFolder() throws IOException {
-    service.files().get(ROOT_FOLDER_ID).setSupportsAllDrives(true).execute();
-  }
-
   public void isFolderAccessible(String folderId) throws IOException {
     service.files().get(folderId).setSupportsAllDrives(true).execute();
+  }
+
+  public void isFileAccessible(String fileId) throws IOException {
+    service.files().get(fileId).setSupportsAllDrives(true).execute();
   }
 }

--- a/src/main/java/io/cdap/plugin/google/common/GoogleDriveFilteringClient.java
+++ b/src/main/java/io/cdap/plugin/google/common/GoogleDriveFilteringClient.java
@@ -71,6 +71,10 @@ public class GoogleDriveFilteringClient<C extends GoogleFilteringSourceConfig> e
       String nextToken = "";
       int retrievedFiles = 0;
       int actualFilesNumber = filesNumber;
+      if (IdentifierType.FILE_IDENTIFIER.equals(config.getIdentifierType())) {
+        files.add(service.files().get(config.getFileIdentifier()).setSupportsAllDrives(true).execute());
+        return files;
+      }
       Drive.Files.List request = service.files().list()
         .setSupportsAllDrives(true)
         .setIncludeItemsFromAllDrives(true)

--- a/src/main/java/io/cdap/plugin/google/common/GoogleFilteringSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/google/common/GoogleFilteringSourceConfig.java
@@ -48,6 +48,7 @@ public class GoogleFilteringSourceConfig extends GoogleAuthBaseConfig {
   protected String filter;
 
   @Name(MODIFICATION_DATE_RANGE)
+  @Nullable
   @Description("Filter that narrows set of files by modified date range. \n" +
     "User can select either among predefined or custom entered ranges. \n" +
     "For _Custom_ selection the dates range can be specified via **Start date** and **End date**.")
@@ -98,7 +99,7 @@ public class GoogleFilteringSourceConfig extends GoogleAuthBaseConfig {
   }
 
   private boolean validateModificationDateRange(FailureCollector collector) {
-    if (!containsMacro(MODIFICATION_DATE_RANGE)) {
+    if (!containsMacro(MODIFICATION_DATE_RANGE) && IdentifierType.DIRECTORY_IDENTIFIER.equals(getIdentifierType())) {
       try {
         getModificationDateRangeType();
         return true;

--- a/src/main/java/io/cdap/plugin/google/common/IdentifierType.java
+++ b/src/main/java/io/cdap/plugin/google/common/IdentifierType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Cask Data, Inc.
+ * Copyright © 2024 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,16 +17,9 @@
 package io.cdap.plugin.google.common;
 
 /**
- * Wrapper to save validation results. Is used to transfer validation results.
+ * Identifier type specifies whether the selected Google Drive entity is a file or directory.
  */
-public class ValidationResult {
-  private boolean directoryOrFileAccessible = false;
-
-  public boolean isDirectoryOrFileAccessible() {
-    return directoryOrFileAccessible;
-  }
-
-  public void setDirectoryOrFileAccessible(boolean directoryOrFileAccessible) {
-    this.directoryOrFileAccessible = directoryOrFileAccessible;
-  }
+public enum IdentifierType {
+  FILE_IDENTIFIER,
+  DIRECTORY_IDENTIFIER
 }

--- a/src/main/java/io/cdap/plugin/google/common/OAuthMethod.java
+++ b/src/main/java/io/cdap/plugin/google/common/OAuthMethod.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.google.common;
+
+/**
+ * Methods of getting an OAuth access token.
+ */
+public enum OAuthMethod {
+  ACCESS_TOKEN,
+  REFRESH_TOKEN;
+}

--- a/src/main/java/io/cdap/plugin/google/drive/source/GoogleDriveSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/google/drive/source/GoogleDriveSourceConfig.java
@@ -364,6 +364,12 @@ public class GoogleDriveSourceConfig extends GoogleFilteringSourceConfig {
     if (properties.has(GoogleDriveSourceConfig.REFRESH_TOKEN)) {
       googleDriveSourceConfig.setRefreshToken(properties.get(GoogleDriveSourceConfig.REFRESH_TOKEN).getAsString());
     }
+    if (properties.has(GoogleDriveSourceConfig.ACCESS_TOKEN)) {
+      googleDriveSourceConfig.setAccessToken(properties.get(GoogleDriveSourceConfig.ACCESS_TOKEN).getAsString());
+    }
+    if (properties.has(GoogleDriveSourceConfig.OAUTH_METHOD)) {
+      googleDriveSourceConfig.setoAuthMethod(properties.get(GoogleDriveSourceConfig.OAUTH_METHOD).getAsString());
+    }
     return googleDriveSourceConfig;
   }
 }

--- a/src/main/java/io/cdap/plugin/google/drive/source/GoogleDriveSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/google/drive/source/GoogleDriveSourceConfig.java
@@ -370,6 +370,14 @@ public class GoogleDriveSourceConfig extends GoogleFilteringSourceConfig {
     if (properties.has(GoogleDriveSourceConfig.OAUTH_METHOD)) {
       googleDriveSourceConfig.setoAuthMethod(properties.get(GoogleDriveSourceConfig.OAUTH_METHOD).getAsString());
     }
+    if (properties.has(GoogleDriveSourceConfig.FILE_IDENTIFIER)) {
+      googleDriveSourceConfig.setFileIdentifier(
+        properties.get(GoogleDriveSourceConfig.FILE_IDENTIFIER).getAsString());
+    }
+    if (properties.has(GoogleDriveSourceConfig.IDENTIFIER_TYPE)) {
+      googleDriveSourceConfig.setIdentifierType(
+        properties.get(GoogleDriveSourceConfig.IDENTIFIER_TYPE).getAsString());
+    }
     return googleDriveSourceConfig;
   }
 }

--- a/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsRecordReader.java
+++ b/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsRecordReader.java
@@ -17,6 +17,7 @@
 package io.cdap.plugin.google.sheets.source;
 
 import com.github.rholder.retry.RetryException;
+import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.gson.reflect.TypeToken;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
@@ -89,48 +90,55 @@ public class GoogleSheetsRecordReader extends RecordReader<NullWritable, Structu
   }
 
   private void populateBufferedTasks() {
-    int firstDataRow = config.getActualFirstDataRow();
-    int lastDataRow = config.getActualLastDataRow();
-    List<String> sheetTitles;
+    List<Sheet> sheetList;
     try {
-      sheetTitles = getSheetTitles();
+      sheetList = getSheetList();
     } catch (ExecutionException | RetryException e) {
       throw new RuntimeException("Exception during sheet titles retrieving.", e);
     }
-    sheetTitles.forEach(t -> {
+    sheetList.forEach(t -> {
+      int firstDataRow = config.getActualFirstDataRow();
+      // Each sheet can have different number of records so last row can be different sheet wise
+      // and in case auto-detect for rows is enabled, It will fetch all records from the sheet
+      int lastDataRow = config.getActualLastDataRow(t.getProperties().getGridProperties().getRowCount());
       int rowsNumber = lastDataRow - firstDataRow + 1;
       overallRowsNumber += rowsNumber;
       int counter = 0;
+      String title = t.getProperties().getTitle();
       while (rowsNumber > bufferSize) {
-        rowTaskQueue.add(new GroupedRowTask(t, counter * bufferSize + firstDataRow, bufferSize));
+        rowTaskQueue.add(
+          new GroupedRowTask(title, counter * bufferSize + firstDataRow, bufferSize));
         counter++;
         rowsNumber -= bufferSize;
       }
-      rowTaskQueue.add(new GroupedRowTask(t, counter * bufferSize + firstDataRow,
+      rowTaskQueue.add(new GroupedRowTask(title, counter * bufferSize + firstDataRow,
         rowsNumber));
     });
     currentRowIndex = -1;
     currentGroupedRowTask = null;
   }
 
-  private List<String> getSheetTitles() throws ExecutionException, RetryException {
-    List<String> sheetTitles = new ArrayList<>();
+  private List<Sheet> getSheetList() throws ExecutionException, RetryException {
+    List<Sheet> sheetList = new ArrayList<>();
     switch (config.getSheetsToPull()) {
       case ALL:
-        sheetTitles = googleSheetsSourceClient.getSheetsTitles(fileId);
+        sheetList = googleSheetsSourceClient.getSheets(fileId);
         break;
       case NUMBERS:
         List<Integer> sheetIndexes = config.getSheetsIdentifiers().stream()
           .map(s -> Integer.parseInt(s)).collect(Collectors.toList());
-        sheetTitles = googleSheetsSourceClient.getSheets(fileId).stream()
+        sheetList = googleSheetsSourceClient.getSheets(fileId).stream()
           .filter(s -> sheetIndexes.contains(s.getProperties().getIndex()))
-          .map(s -> s.getProperties().getTitle()).collect(Collectors.toList());
+          .collect(Collectors.toList());
         break;
       case TITLES:
-        sheetTitles = config.getSheetsIdentifiers();
+        List<String> sheetTitles = config.getSheetsIdentifiers();
+        sheetList = googleSheetsSourceClient.getSheets(fileId).stream()
+          .filter(s -> sheetTitles.contains(s.getProperties().getTitle()))
+          .collect(Collectors.toList());
         break;
     }
-    return sheetTitles;
+    return sheetList;
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsSourceConfig.java
@@ -285,7 +285,8 @@ public class GoogleSheetsSourceConfig extends GoogleFilteringSourceConfig {
       !containsMacro(ACCOUNT_FILE_PATH) && !containsMacro(NAME_SERVICE_ACCOUNT_JSON) &&
       !containsMacro(CLIENT_ID) && !containsMacro(CLIENT_SECRET) &&
       !containsMacro(REFRESH_TOKEN) && !containsMacro(ACCESS_TOKEN) &&
-      !containsMacro(OAUTH_METHOD);
+      !containsMacro(OAUTH_METHOD) && !containsMacro(FILE_IDENTIFIER) &&
+      !containsMacro(DIRECTORY_IDENTIFIER);
   }
 
   /**
@@ -303,7 +304,7 @@ public class GoogleSheetsSourceConfig extends GoogleFilteringSourceConfig {
     validateLastDataColumnIndexAndLastRowIndex(collector);
     validateSpreadsheetAndSheetFieldNames(collector);
 
-    if (collector.getValidationFailures().isEmpty() && validationResult.isDirectoryAccessible()) {
+    if (collector.getValidationFailures().isEmpty() && validationResult.isDirectoryOrFileAccessible()) {
       GoogleDriveFilteringClient driveClient;
       GoogleSheetsSourceClient sheetsSourceClient;
       try {
@@ -318,7 +319,8 @@ public class GoogleSheetsSourceConfig extends GoogleFilteringSourceConfig {
         spreadsheetsFiles = driveClient
           .getFilesSummary(Collections.singletonList(ExportedType.SPREADSHEETS), 1);
       } catch (ExecutionException | RetryException e) {
-        collector.addFailure("Invalid search query, see https://developers.google.com/drive/api/v3/ref-search-terms",
+        collector.addFailure(
+          String.format("Failed to get spreadsheet file summary due to reason : %s", e.getMessage()),
                         null).withStacktrace(e.getStackTrace());
         return validationResult;
       }
@@ -1270,6 +1272,15 @@ public class GoogleSheetsSourceConfig extends GoogleFilteringSourceConfig {
       googleSheetsSourceConfig.setAccessToken(
         properties.get(GoogleSheetsSourceConfig.ACCESS_TOKEN).getAsString());
     }
+    if (properties.has(GoogleSheetsSourceConfig.FILE_IDENTIFIER)) {
+      googleSheetsSourceConfig.setFileIdentifier(
+        properties.get(GoogleSheetsSourceConfig.FILE_IDENTIFIER).getAsString());
+    }
+    if (properties.has(GoogleSheetsSourceConfig.IDENTIFIER_TYPE)) {
+      googleSheetsSourceConfig.setIdentifierType(
+        properties.get(GoogleSheetsSourceConfig.IDENTIFIER_TYPE).getAsString());
+    }
+
     return googleSheetsSourceConfig;
   }
 }

--- a/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsSourceConfig.java
@@ -282,7 +282,10 @@ public class GoogleSheetsSourceConfig extends GoogleFilteringSourceConfig {
     return !containsMacro(SHEETS_TO_PULL) && !containsMacro(SHEETS_IDENTIFIERS) &&
       !containsMacro(COLUMN_NAMES_SELECTION) && !containsMacro(CUSTOM_COLUMN_NAMES_ROW) &&
       !containsMacro(LAST_DATA_COLUMN) && !containsMacro(NAME_SERVICE_ACCOUNT_TYPE) &&
-      !containsMacro(ACCOUNT_FILE_PATH) && !containsMacro(NAME_SERVICE_ACCOUNT_JSON);
+      !containsMacro(ACCOUNT_FILE_PATH) && !containsMacro(NAME_SERVICE_ACCOUNT_JSON) &&
+      !containsMacro(CLIENT_ID) && !containsMacro(CLIENT_SECRET) &&
+      !containsMacro(REFRESH_TOKEN) && !containsMacro(ACCESS_TOKEN) &&
+      !containsMacro(OAUTH_METHOD);
   }
 
   /**
@@ -1258,6 +1261,15 @@ public class GoogleSheetsSourceConfig extends GoogleFilteringSourceConfig {
         properties.get(GoogleSheetsSourceConfig.DIRECTORY_IDENTIFIER).getAsString());
     }
 
+    if (properties.has(GoogleSheetsSourceConfig.OAUTH_METHOD)) {
+      googleSheetsSourceConfig.setoAuthMethod(
+        properties.get(GoogleSheetsSourceConfig.OAUTH_METHOD).getAsString());
+    }
+
+    if (properties.has(GoogleSheetsSourceConfig.ACCESS_TOKEN)) {
+      googleSheetsSourceConfig.setAccessToken(
+        properties.get(GoogleSheetsSourceConfig.ACCESS_TOKEN).getAsString());
+    }
     return googleSheetsSourceConfig;
   }
 }

--- a/src/test/java/io/cdap/plugin/google/common/GoogleAuthBaseConfigTest.java
+++ b/src/test/java/io/cdap/plugin/google/common/GoogleAuthBaseConfigTest.java
@@ -57,6 +57,8 @@ public class GoogleAuthBaseConfigTest {
     config.setModificationDateRange("today");
     config.getBodyFormat("string");
     config.setStartDate("today");
+    config.setIdentifierType(IdentifierType.FILE_IDENTIFIER.name());
+    config.setFileIdentifier("fileId");
     FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
     config.validate(collector);
     Assert.assertEquals(1, collector.getValidationFailures().size());
@@ -76,6 +78,8 @@ public class GoogleAuthBaseConfigTest {
     config.setModificationDateRange("today");
     config.getBodyFormat("string");
     config.setStartDate("today");
+    config.setFileIdentifier("fileId");
+    config.setIdentifierType(IdentifierType.FILE_IDENTIFIER.name());
     FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
     config.validate(collector);
     Assert.assertEquals(1, collector.getValidationFailures().size());
@@ -94,6 +98,8 @@ public class GoogleAuthBaseConfigTest {
     config.setModificationDateRange("today");
     config.getBodyFormat("string");
     config.setStartDate("today");
+    config.setIdentifierType(IdentifierType.FILE_IDENTIFIER.name());
+    config.setFileIdentifier("fileId");
     FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
     config.validate(collector);
     Assert.assertEquals(1, collector.getValidationFailures().size());
@@ -112,6 +118,8 @@ public class GoogleAuthBaseConfigTest {
     config.setModificationDateRange("today");
     config.getBodyFormat("string");
     config.setStartDate("today");
+    config.setFileIdentifier("fileId");
+    config.setIdentifierType(IdentifierType.FILE_IDENTIFIER.name());
     FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
     config.validate(collector);
     Assert.assertEquals(3, collector.getValidationFailures().size());
@@ -127,5 +135,50 @@ public class GoogleAuthBaseConfigTest {
                         collector.getValidationFailures().get(1).getCauses().get(0).getAttribute("stageConfig"));
     Assert.assertEquals("refreshToken",
                         collector.getValidationFailures().get(2).getCauses().get(0).getAttribute("stageConfig"));
+  }
+
+  @Test
+  public void testWithDirectoryIdAsNull() {
+    GoogleDriveSourceConfig config = new GoogleDriveSourceConfig("ref");
+    config.setReferenceName("validationErrorFilePath");
+    config.setAuthType("oAuth2");
+    config.setModificationDateRange("today");
+    config.getBodyFormat("string");
+    config.setStartDate("today");
+    config.setAccessToken("access");
+    config.setoAuthMethod(OAuthMethod.ACCESS_TOKEN.name());
+    FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
+    config.validate(collector);
+    Assert.assertEquals(2, collector.getValidationFailures().size());
+    Assert.assertEquals("Directory Identifier can not be null.",
+                        collector.getValidationFailures().get(0).getMessage());
+    Assert.assertEquals("directoryIdentifier",
+                        collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
+    Assert.assertEquals("Exception during authentication/directory properties check: " +
+                          "Errors were encountered during validation. Directory Identifier can not be null..",
+                        collector.getValidationFailures().get(1).getMessage());
+  }
+
+  @Test
+  public void testWithFileIdAsNull() {
+    GoogleDriveSourceConfig config = new GoogleDriveSourceConfig("ref");
+    config.setReferenceName("validationErrorFilePath");
+    config.setAuthType("oAuth2");
+    config.setModificationDateRange("today");
+    config.getBodyFormat("string");
+    config.setStartDate("today");
+    config.setAccessToken("access");
+    config.setIdentifierType(IdentifierType.FILE_IDENTIFIER.name());
+    config.setoAuthMethod(OAuthMethod.ACCESS_TOKEN.name());
+    FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
+    config.validate(collector);
+    Assert.assertEquals(2, collector.getValidationFailures().size());
+    Assert.assertEquals("File Identifier can not be null.",
+                        collector.getValidationFailures().get(0).getMessage());
+    Assert.assertEquals("fileIdentifier",
+                        collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
+    Assert.assertEquals("Exception during authentication/directory properties check: " +
+                          "Errors were encountered during validation. File Identifier can not be null..",
+                        collector.getValidationFailures().get(1).getMessage());
   }
 }

--- a/src/test/java/io/cdap/plugin/google/common/GoogleAuthBaseConfigTest.java
+++ b/src/test/java/io/cdap/plugin/google/common/GoogleAuthBaseConfigTest.java
@@ -84,4 +84,48 @@ public class GoogleAuthBaseConfigTest {
     Assert.assertEquals("serviceAccountJSON",
                         collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
   }
+
+  @Test
+  public void testValidationOauthWithoutAccessToken() {
+    GoogleDriveSourceConfig config = new GoogleDriveSourceConfig("ref");
+    config.setReferenceName("validationErrorFilePath");
+    config.setAuthType("oAuth2");
+    config.setoAuthMethod(OAuthMethod.ACCESS_TOKEN.name());
+    config.setModificationDateRange("today");
+    config.getBodyFormat("string");
+    config.setStartDate("today");
+    FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
+    config.validate(collector);
+    Assert.assertEquals(1, collector.getValidationFailures().size());
+    Assert.assertEquals("'Access Token' property is empty or macro is not available.",
+                        collector.getValidationFailures().get(0).getMessage());
+    Assert.assertEquals("accessToken",
+                        collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
+  }
+
+  @Test
+  public void testValidationOauthWithoutRefreshToken() {
+    GoogleDriveSourceConfig config = new GoogleDriveSourceConfig(null);
+    config.setReferenceName("validationErrorFilePath");
+    config.setAuthType("oAuth2");
+    config.setoAuthMethod(OAuthMethod.REFRESH_TOKEN.name());
+    config.setModificationDateRange("today");
+    config.getBodyFormat("string");
+    config.setStartDate("today");
+    FailureCollector collector = new DefaultFailureCollector("stageConfig", Collections.EMPTY_MAP);
+    config.validate(collector);
+    Assert.assertEquals(3, collector.getValidationFailures().size());
+    Assert.assertEquals("'Client ID' property is empty or macro is not available.",
+                        collector.getValidationFailures().get(0).getMessage());
+    Assert.assertEquals("'Client Secret' property is empty or macro is not available.",
+                        collector.getValidationFailures().get(1).getMessage());
+    Assert.assertEquals("'Refresh Token' property is empty or macro is not available.",
+                        collector.getValidationFailures().get(2).getMessage());
+    Assert.assertEquals("clientId",
+                        collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
+    Assert.assertEquals("clientSecret",
+                        collector.getValidationFailures().get(1).getCauses().get(0).getAttribute("stageConfig"));
+    Assert.assertEquals("refreshToken",
+                        collector.getValidationFailures().get(2).getCauses().get(0).getAttribute("stageConfig"));
+  }
 }

--- a/src/test/java/io/cdap/plugin/google/common/GoogleAuthBaseConfigTest.java
+++ b/src/test/java/io/cdap/plugin/google/common/GoogleAuthBaseConfigTest.java
@@ -155,7 +155,7 @@ public class GoogleAuthBaseConfigTest {
     Assert.assertEquals("directoryIdentifier",
                         collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
     Assert.assertEquals("Exception during authentication/directory properties check: " +
-                          "Errors were encountered during validation. Directory Identifier can not be null..",
+                          "Errors were encountered during validation..",
                         collector.getValidationFailures().get(1).getMessage());
   }
 
@@ -178,7 +178,7 @@ public class GoogleAuthBaseConfigTest {
     Assert.assertEquals("fileIdentifier",
                         collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
     Assert.assertEquals("Exception during authentication/directory properties check: " +
-                          "Errors were encountered during validation. File Identifier can not be null..",
+                          "Errors were encountered during validation..",
                         collector.getValidationFailures().get(1).getMessage());
   }
 }

--- a/src/test/java/io/cdap/plugin/google/sheets/sink/GoogleSheetsSinkClientTest.java
+++ b/src/test/java/io/cdap/plugin/google/sheets/sink/GoogleSheetsSinkClientTest.java
@@ -21,6 +21,7 @@ import com.google.api.services.sheets.v4.model.GridRange;
 import com.google.api.services.sheets.v4.model.MergeCellsRequest;
 import com.google.api.services.sheets.v4.model.RowData;
 import io.cdap.plugin.google.common.AuthType;
+import io.cdap.plugin.google.common.OAuthMethod;
 import io.cdap.plugin.google.sheets.sink.utils.ComplexHeader;
 import io.cdap.plugin.google.sheets.sink.utils.FlatteredRowsRecord;
 import io.cdap.plugin.google.sheets.sink.utils.FlatteredRowsRequest;
@@ -49,7 +50,7 @@ public class GoogleSheetsSinkClientTest {
     EasyMock.expect(sinkConfig.getRefreshToken()).andReturn("dsfdsfdsfdsf").anyTimes();
     EasyMock.expect(sinkConfig.getClientSecret()).andReturn("dsfdsfdsfdsf").anyTimes();
     EasyMock.expect(sinkConfig.getClientId()).andReturn("dsdsrfegvrb").anyTimes();
-
+    EasyMock.expect(sinkConfig.getOAuthMethod()).andReturn(OAuthMethod.REFRESH_TOKEN).anyTimes();
     EasyMock.replay(sinkConfig);
     sinkClient = new GoogleSheetsSinkClient(sinkConfig);
 

--- a/widgets/GoogleDrive-batchsink.json
+++ b/widgets/GoogleDrive-batchsink.json
@@ -57,6 +57,33 @@
           }
         },
         {
+          "name": "oAuthMethod",
+          "label": "OAuth Method",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "REFRESH_TOKEN",
+            "options": [
+              {
+                "id": "REFRESH_TOKEN",
+                "label": "Refresh Token"
+              },
+              {
+                "id": "ACCESS_TOKEN",
+                "label": "Access Token"
+              }
+            ]
+          }
+        },
+        {
+          "name": "accessToken",
+          "label": "Access Token",
+          "widget-type": "textbox",
+          "widget-attributes": {
+            "placeholder": "${oauthAccessToken(provider,credential)}"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Client ID",
           "name": "clientId"
@@ -114,6 +141,30 @@
         "property": "authType",
         "operator": "equal to",
         "value": "oAuth2"
+      },
+      "show": [
+        {
+          "name": "oAuthMethod",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Access Token",
+      "condition": {
+        "expression": "oAuthMethod == 'ACCESS_TOKEN' && authType == 'oAuth2'"
+      },
+      "show": [
+        {
+          "name": "accessToken",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Refresh Token",
+      "condition": {
+        "expression": "oAuthMethod == null || (oAuthMethod != 'ACCESS_TOKEN' && authType == 'oAuth2')"
       },
       "show": [
         {

--- a/widgets/GoogleDrive-batchsink.json
+++ b/widgets/GoogleDrive-batchsink.json
@@ -31,6 +31,16 @@
           "widget-type": "textbox",
           "label": "Directory Identifier",
           "name": "directoryIdentifier"
+        },
+        {
+          "widget-type": "hidden",
+          "label": "File Identifier",
+          "name": "fileIdentifier"
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Identifier Type",
+          "name": "identifierType"
         }
       ]
     },

--- a/widgets/GoogleDrive-batchsource.json
+++ b/widgets/GoogleDrive-batchsource.json
@@ -312,6 +312,33 @@
           }
         },
         {
+          "name": "oAuthMethod",
+          "label": "OAuth Method",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "REFRESH_TOKEN",
+            "options": [
+              {
+                "id": "REFRESH_TOKEN",
+                "label": "Refresh Token"
+              },
+              {
+                "id": "ACCESS_TOKEN",
+                "label": "Access Token"
+              }
+            ]
+          }
+        },
+        {
+          "name": "accessToken",
+          "label": "Access Token",
+          "widget-type": "textbox",
+          "widget-attributes": {
+            "placeholder": "${oauthAccessToken(provider,credential)}"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Client ID",
           "name": "clientId"
@@ -487,6 +514,30 @@
         "property": "authType",
         "operator": "equal to",
         "value": "oAuth2"
+      },
+      "show": [
+        {
+          "name": "oAuthMethod",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Access Token",
+      "condition": {
+        "expression": "oAuthMethod == 'ACCESS_TOKEN' && authType == 'oAuth2'"
+      },
+      "show": [
+        {
+          "name": "accessToken",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Refresh Token",
+      "condition": {
+        "expression": "oAuthMethod == null || (oAuthMethod != 'ACCESS_TOKEN' && authType == 'oAuth2')"
       },
       "show": [
         {

--- a/widgets/GoogleDrive-batchsource.json
+++ b/widgets/GoogleDrive-batchsource.json
@@ -13,9 +13,33 @@
           "name": "referenceName"
         },
         {
+          "name": "identifierType",
+          "label": "Identifier Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "DIRECTORY_IDENTIFIER",
+            "options": [
+              {
+                "id": "DIRECTORY_IDENTIFIER",
+                "label": "Directory Identifier"
+              },
+              {
+                "id": "FILE_IDENTIFIER",
+                "label": "File Identifier"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Directory Identifier",
           "name": "directoryIdentifier"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "File Identifier",
+          "name": "fileIdentifier"
         },
         {
           "name": "fileMetadataProperties",
@@ -537,7 +561,7 @@
     {
       "name": "Authenticate with OAuth2 Refresh Token",
       "condition": {
-        "expression": "oAuthMethod == null || (oAuthMethod != 'ACCESS_TOKEN' && authType == 'oAuth2')"
+        "expression": "oAuthMethod != 'ACCESS_TOKEN' && authType == 'oAuth2'"
       },
       "show": [
         {
@@ -589,6 +613,48 @@
         {
           "type": "property",
           "name": "serviceAccountJSON"
+        }
+      ]
+    },
+    {
+      "name": "Select Identifier Type",
+      "condition": {
+        "expression": "identifierType != 'FILE_IDENTIFIER'"
+      },
+      "show": [
+        {
+          "name": "directoryIdentifier",
+          "type": "property"
+        },
+        {
+          "name": "startDate",
+          "type": "property"
+        },
+        {
+          "name": "endDate",
+          "type": "property"
+        },
+        {
+          "name": "filter",
+          "type": "property"
+        },
+        {
+          "name": "modificationDateRange",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Select Identifier Type",
+      "condition": {
+        "property": "identifierType",
+        "operator": "equal to",
+        "value": "FILE_IDENTIFIER"
+      },
+      "show": [
+        {
+          "name": "fileIdentifier",
+          "type": "property"
         }
       ]
     }

--- a/widgets/GoogleSheets-batchsink.json
+++ b/widgets/GoogleSheets-batchsink.json
@@ -18,6 +18,16 @@
           "name": "directoryIdentifier"
         },
         {
+          "widget-type": "hidden",
+          "label": "File Identifier",
+          "name": "fileIdentifier"
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Identifier Type",
+          "name": "identifierType"
+        },
+        {
           "widget-type": "textbox",
           "label": "Spreadsheet Name Field",
           "name": "schemaSpreadsheetNameFieldName"

--- a/widgets/GoogleSheets-batchsink.json
+++ b/widgets/GoogleSheets-batchsink.json
@@ -116,6 +116,33 @@
           "name": "serviceAccountJSON"
         },
         {
+          "name": "oAuthMethod",
+          "label": "OAuth Method",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "REFRESH_TOKEN",
+            "options": [
+              {
+                "id": "REFRESH_TOKEN",
+                "label": "Refresh Token"
+              },
+              {
+                "id": "ACCESS_TOKEN",
+                "label": "Access Token"
+              }
+            ]
+          }
+        },
+        {
+          "name": "accessToken",
+          "label": "Access Token",
+          "widget-type": "textbox",
+          "widget-attributes": {
+            "placeholder": "${oauthAccessToken(provider,credential)}"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Client ID",
           "name": "clientId"
@@ -234,7 +261,33 @@
     {
       "name": "Authenticate with OAuth2",
       "condition": {
-        "expression": "authType == 'oAuth2'"
+        "property": "authType",
+        "operator": "equal to",
+        "value": "oAuth2"
+      },
+      "show": [
+        {
+          "name": "oAuthMethod",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Access Token",
+      "condition": {
+        "expression": "oAuthMethod == 'ACCESS_TOKEN' && authType == 'oAuth2'"
+      },
+      "show": [
+        {
+          "name": "accessToken",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Refresh Token",
+      "condition": {
+        "expression": "oAuthMethod == null || (oAuthMethod != 'ACCESS_TOKEN' && authType == 'oAuth2')"
       },
       "show": [
         {

--- a/widgets/GoogleSheets-batchsource.json
+++ b/widgets/GoogleSheets-batchsource.json
@@ -388,6 +388,22 @@
           }
         },
         {
+          "widget-type": "toggle",
+          "label": "Auto Detect Number of Rows and Columns",
+          "name": "autoDetectRowsAndColumns",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "Yes"
+            },
+            "off": {
+              "value": "false",
+              "label": "No"
+            },
+            "default": "true"
+          }
+        },
+        {
           "widget-type": "number",
           "label": "Number of Columns to Read",
           "name": "lastDataColumn",
@@ -629,6 +645,22 @@
       "show": [
         {
           "name": "fileIdentifier",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Auto Detect Rows and Columns",
+      "condition": {
+        "expression": "autoDetectRowsAndColumns != true"
+      },
+      "show": [
+        {
+          "name": "lastDataColumn",
+          "type": "property"
+        },
+        {
+          "name": "lastDataRow",
           "type": "property"
         }
       ]

--- a/widgets/GoogleSheets-batchsource.json
+++ b/widgets/GoogleSheets-batchsource.json
@@ -144,6 +144,33 @@
           "name": "serviceAccountJSON"
         },
         {
+          "name": "oAuthMethod",
+          "label": "OAuth Method",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "REFRESH_TOKEN",
+            "options": [
+              {
+                "id": "REFRESH_TOKEN",
+                "label": "Refresh Token"
+              },
+              {
+                "id": "ACCESS_TOKEN",
+                "label": "Access Token"
+              }
+            ]
+          }
+        },
+        {
+          "name": "accessToken",
+          "label": "Access Token",
+          "widget-type": "textbox",
+          "widget-attributes": {
+            "placeholder": "${oauthAccessToken(provider,credential)}"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Client ID",
           "name": "clientId"
@@ -404,6 +431,30 @@
         "property": "authType",
         "operator": "equal to",
         "value": "oAuth2"
+      },
+      "show": [
+        {
+          "name": "oAuthMethod",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Access Token",
+      "condition": {
+        "expression": "oAuthMethod == 'ACCESS_TOKEN' && authType == 'oAuth2'"
+      },
+      "show": [
+        {
+          "name": "accessToken",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Authenticate with OAuth2 Refresh Token",
+      "condition": {
+        "expression": "oAuthMethod == null || (oAuthMethod != 'ACCESS_TOKEN' && authType == 'oAuth2')"
       },
       "show": [
         {

--- a/widgets/GoogleSheets-batchsource.json
+++ b/widgets/GoogleSheets-batchsource.json
@@ -13,9 +13,33 @@
           "name": "referenceName"
         },
         {
+          "name": "identifierType",
+          "label": "Identifier Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "DIRECTORY_IDENTIFIER",
+            "options": [
+              {
+                "id": "DIRECTORY_IDENTIFIER",
+                "label": "Directory Identifier"
+              },
+              {
+                "id": "FILE_IDENTIFIER",
+                "label": "File Identifier"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Directory Identifier",
           "name": "directoryIdentifier"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "File Identifier",
+          "name": "fileIdentifier"
         }
       ]
     },
@@ -454,7 +478,7 @@
     {
       "name": "Authenticate with OAuth2 Refresh Token",
       "condition": {
-        "expression": "oAuthMethod == null || (oAuthMethod != 'ACCESS_TOKEN' && authType == 'oAuth2')"
+        "expression": "oAuthMethod != 'ACCESS_TOKEN' && authType == 'oAuth2'"
       },
       "show": [
         {
@@ -571,6 +595,40 @@
         },
         {
           "name": "sheetFieldName",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Select Identifier Type",
+      "condition": {
+        "expression": "identifierType != 'FILE_IDENTIFIER'"
+      },
+      "show": [
+        {
+          "name": "directoryIdentifier",
+          "type": "property"
+        },
+        {
+          "name": "filter",
+          "type": "property"
+        },
+        {
+          "name": "modificationDateRange",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Select Identifier Type",
+      "condition": {
+        "property": "identifierType",
+        "operator": "equal to",
+        "value": "FILE_IDENTIFIER"
+      },
+      "show": [
+        {
+          "name": "fileIdentifier",
           "type": "property"
         }
       ]


### PR DESCRIPTION
-https://github.com/data-integrations/google-drive/pull/43
[PLUGIN-1762] Macros added for oauth fields- clientId, clientSecret and refresh token.
[PLUGIN-1764] Access token field added that can be used with oauthAccessToken macro.

-https://github.com/data-integrations/google-drive/pull/44
[PLUGIN-1763]User can specify the file id instead of directory identifier and providing filters.

-https://github.com/data-integrations/google-drive/pull/45
[PLUGIN-1766]Added support to get all the rows and columns of google sheets instead of specifying the number each time.

