### PR TITLE
[PLUGIN-1817] Added check for non-spreadsheet files with proper error.

### DIFF
--- a/src/main/java/io/cdap/plugin/google/common/GoogleDriveFilteringClient.java
+++ b/src/main/java/io/cdap/plugin/google/common/GoogleDriveFilteringClient.java
@@ -72,9 +72,10 @@ public class GoogleDriveFilteringClient<C extends GoogleFilteringSourceConfig> e
       int retrievedFiles = 0;
       int actualFilesNumber = filesNumber;
       if (IdentifierType.FILE_IDENTIFIER.equals(config.getIdentifierType())) {
-        files.add(service.files().get(config.getFileIdentifier()).setSupportsAllDrives(true).execute());
+        files.add(getFilesSummaryByFileId());
         return files;
       }
+
       Drive.Files.List request = service.files().list()
         .setSupportsAllDrives(true)
         .setIncludeItemsFromAllDrives(true)
@@ -97,6 +98,10 @@ public class GoogleDriveFilteringClient<C extends GoogleFilteringSourceConfig> e
           files.subList(0, actualFilesNumber);
 
     });
+  }
+
+  protected File getFilesSummaryByFileId() throws IOException, ExecutionException {
+    return service.files().get(config.getFileIdentifier()).setSupportsAllDrives(true).execute();
   }
 
   private String generateFilter(List<ExportedType> exportedTypes) throws InterruptedException {

--- a/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsFilteringClient.java
+++ b/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsFilteringClient.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.google.sheets.source;
+
+import com.google.api.services.drive.model.File;
+import io.cdap.plugin.google.common.GoogleDriveFilteringClient;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Client for getting File information via Google Sheets API.
+ */
+public class GoogleSheetsFilteringClient extends GoogleDriveFilteringClient<GoogleSheetsSourceConfig> {
+
+  public GoogleSheetsFilteringClient(GoogleSheetsSourceConfig config) throws IOException {
+    super(config);
+  }
+
+  @Override
+  protected File getFilesSummaryByFileId() throws IOException, ExecutionException {
+    File file = service.files().get(config.getFileIdentifier()).setSupportsAllDrives(true).execute();
+    if (!file.getMimeType().equalsIgnoreCase(DRIVE_SPREADSHEETS_MIME)) {
+      throw new ExecutionException(
+        String.format("File with id: '%s' has a MIME_TYPE '%s' and is not a Google Sheets File.",
+                      file.getMimeType(),
+                      config.getFileIdentifier()), null);
+    }
+    return file;
+  }
+}

--- a/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsInputFormat.java
+++ b/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsInputFormat.java
@@ -57,7 +57,7 @@ public class GoogleSheetsInputFormat extends InputFormat {
         GoogleSheetsInputFormatProvider.GSON.fromJson(headersJson, headersType);
 
     // get all sheets files according to filter
-    GoogleDriveFilteringClient driveFilteringClient = new GoogleDriveFilteringClient(googleSheetsSourceConfig);
+    GoogleDriveFilteringClient driveFilteringClient = new GoogleSheetsFilteringClient(googleSheetsSourceConfig);
     List<File> spreadsheetsFiles;
     try {
       spreadsheetsFiles = driveFilteringClient.getFilesSummary(Collections.singletonList(ExportedType.SPREADSHEETS));

--- a/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsSourceConfig.java
@@ -334,7 +334,7 @@ public class GoogleSheetsSourceConfig extends GoogleFilteringSourceConfig {
       GoogleDriveFilteringClient driveClient;
       GoogleSheetsSourceClient sheetsSourceClient;
       try {
-        driveClient = new GoogleDriveFilteringClient(this);
+        driveClient = new GoogleSheetsFilteringClient(this);
         sheetsSourceClient = new GoogleSheetsSourceClient(this);
       } catch (IOException e) {
         collector.addFailure("Exception during drive and sheets connections instantiating.", null);

--- a/src/main/java/io/cdap/plugin/google/sheets/source/SheetTransformer.java
+++ b/src/main/java/io/cdap/plugin/google/sheets/source/SheetTransformer.java
@@ -69,7 +69,8 @@ public class SheetTransformer {
         builder.set(metadataRecordName, rowRecord.getMetadata());
       } else {
         ComplexSingleValueColumn complexSingleValueColumn = rowRecord.getHeaderedCells().get(name);
-        if (complexSingleValueColumn.getData() == null && complexSingleValueColumn.getSubColumns().isEmpty()) {
+        if (complexSingleValueColumn == null || (complexSingleValueColumn.getData() == null
+          && complexSingleValueColumn.getSubColumns().isEmpty())) {
           builder.set(name, null);
         } else {
           processCellData(builder, field, complexSingleValueColumn);

--- a/src/test/java/io/cdap/plugin/google/common/APIRequestRetryerTest.java
+++ b/src/test/java/io/cdap/plugin/google/common/APIRequestRetryerTest.java
@@ -33,14 +33,12 @@ import java.util.concurrent.ExecutionException;
 @PrepareForTest({GoogleJsonResponseException.class})
 public class APIRequestRetryerTest {
   private static final int UNPROCESSED_CODE = 504;
-  private static final int RETRY_NUMBER = 8;
+  private static final int RETRY_NUMBER = 10;
 
   @Test
   public void testRetryCount() throws ExecutionException {
     GoogleJsonResponseException exception = PowerMockito.mock(GoogleJsonResponseException.class);
-    GoogleJsonError googleJsonError = new GoogleJsonError();
-    googleJsonError.setCode(APIRequestRetryer.TOO_MANY_REQUESTS_CODE);
-    PowerMockito.when(exception.getDetails()).thenReturn(googleJsonError);
+    PowerMockito.when(exception.getStatusCode()).thenReturn(APIRequestRetryer.TOO_MANY_REQUESTS_CODE);
     PowerMockito.when(exception.getStatusMessage()).thenReturn(APIRequestRetryer.TOO_MANY_REQUESTS_MESSAGE);
 
 


### PR DESCRIPTION
[PLUGIN-1817] Added check for non-spreadsheet files with proper error.

Google Sheets Plugin throws ‘This operation is not supported for this document’ for xls format.

Google Sheets Plugin throws ‘Request contains an invalid argument’ for csv/pdf/doc file format.

Add a proper error mentioning it is not a google spreadsheet file.

[PLUGIN-1817]: https://cdap.atlassian.net/browse/PLUGIN-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ