### PR TITLE
Remove SNAPHOST for release 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>io.cdap.plugin</groupId>
   <name>Google Drive plugins</name>
   <artifactId>google-drive-plugins</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.6.0</version>
   <packaging>jar</packaging>
   <description>Google Drive plugins</description>
 


### PR DESCRIPTION
Remove SNAPHOST for release 1.6.0