### PR TITLE
[cherrypick] [PLUGIN-1958] Add timeout Error message and Bump Up to 1.6.2-SNAPSHOT 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>io.cdap.plugin</groupId>
   <name>Google Drive plugins</name>
   <artifactId>google-drive-plugins</artifactId>
-  <version>1.6.1</version>
+  <version>1.6.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Google Drive plugins</description>
 

--- a/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/google/sheets/source/GoogleSheetsSourceConfig.java
@@ -596,8 +596,8 @@ public class GoogleSheetsSourceConfig extends GoogleFilteringSourceConfig {
         }
       } catch (IOException e) {
         collector.addFailure(
-          String.format("Failed to prepare headers, spreadsheet id: '%s', sheet title: '%s'.",
-            currentSpreadsheetId, currentSheetTitle), null);
+          String.format("Failed to prepare headers, spreadsheet id: '%s', sheet title: '%s' due to reason: '%s'.",
+            currentSpreadsheetId, currentSheetTitle, e.getMessage()), null);
       }
     }
   }

--- a/src/test/java/io/cdap/plugin/google/sheets/source/GoogleSheetsSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/google/sheets/source/GoogleSheetsSourceConfigTest.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.google.sheets.source;
 
+import com.google.api.services.drive.model.File;
 import com.google.api.services.sheets.v4.model.CellData;
 import com.google.api.services.sheets.v4.model.ExtendedValue;
 import com.google.api.services.sheets.v4.model.GridRange;
@@ -27,7 +28,9 @@ import io.cdap.plugin.google.sheets.source.utils.ColumnComplexSchemaInfo;
 import io.cdap.plugin.google.sheets.source.utils.MetadataKeyValueAddress;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -470,5 +473,35 @@ public class GoogleSheetsSourceConfigTest {
     Assert.assertTrue(subColumns.get(0).getSubColumns().isEmpty());
     Assert.assertEquals("d", subColumns.get(1).getHeaderTitle());
     Assert.assertTrue(subColumns.get(0).getSubColumns().isEmpty());
+  }
+
+  @Test
+  public void testGetAndValidateSheetSchemaIOException() throws Exception {
+    FailureCollector collector = new DefaultFailureCollector("", Collections.EMPTY_MAP);
+    GoogleSheetsSourceClient mockClient = Mockito.mock(GoogleSheetsSourceClient.class);
+    
+    List<File> spreadsheetsFiles = new ArrayList<>();
+    File mockFile = new File();
+    mockFile.setId("spreadsheetId");
+    spreadsheetsFiles.add(mockFile);
+    
+    Mockito.when(mockClient.getSheetsTitles("spreadsheetId")).thenReturn(Arrays.asList("Sheet1"));
+    
+    Mockito.when(mockClient.getSingleRows(Mockito.anyString(), Mockito.anyString(), Mockito.anySet()))
+      .thenThrow(new IOException("Mocked IO exception"));
+      
+    setFieldValue("sheetsToPull", "all");
+    setFieldValue("columnNamesSelection", "noColumnNames");
+      
+    Method method = GoogleSheetsSourceConfig.class.getDeclaredMethod("getAndValidateSheetSchema", 
+      FailureCollector.class, GoogleSheetsSourceClient.class, List.class);
+    method.setAccessible(true);
+    
+    method.invoke(config, collector, mockClient, spreadsheetsFiles);
+    
+    Assert.assertEquals(1, collector.getValidationFailures().size());
+    ValidationFailure failure = collector.getValidationFailures().get(0);
+    Assert.assertTrue(failure.getMessage().contains("Failed to prepare headers"));
+    Assert.assertTrue(failure.getMessage().contains("due to reason: 'Mocked IO exception'"));
   }
 }


### PR DESCRIPTION
Bump up to 1.6.2-SNAPSHOT

cherrypick CL: https://github.com/data-integrations/google-drive/pull/82

[PLUGIN-1958](https://cdap.atlassian.net/browse/PLUGIN-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) Added error message reason in case of failures while get Schema


[PLUGIN-1958]: https://cdap.atlassian.net/browse/PLUGIN-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ